### PR TITLE
Add --allow-unauthenticated to apt-get install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 FROM ros:kinetic
 
 # Install software
-RUN apt-get update && apt-get install -y --no-install-recommends apt-utils \
+RUN apt-get update && apt-get install -y --allow-unauthenticated --no-install-recommends apt-utils \
     emacs \
     sudo \
     python-pip \


### PR DESCRIPTION
Include --allow-unauthenticated flag when installing packages to resolve authentication issues encountered when using the -y flag for non-interactive installation.