### PR TITLE
Syncing to upstream

### DIFF
--- a/MAMBAF405MK2V2.conf
+++ b/MAMBAF405MK2V2.conf
@@ -1,0 +1,173 @@
+# 
+
+# diff
+###WARNING: NO CUSTOM DEFAULTS FOUND###
+
+# version
+# Betaflight / STM32F405 (S405) 4.3.2 Nov 28 2022 / 07:26:30 (60c9521) MSP API: 1.44
+###ERROR IN diff: NO CONFIG FOUND###
+# start the command batch
+batch start
+
+board_name FURYF4OSD
+manufacturer_id DIAT
+
+# resources
+resource BEEPER 1 A08
+resource MOTOR 1 A03
+resource MOTOR 2 B00
+resource MOTOR 3 B01
+resource MOTOR 4 A02
+resource PPM 1 C09
+resource LED_STRIP 1 A00
+resource SERIAL_TX 1 A09
+resource SERIAL_TX 3 B10
+resource SERIAL_TX 6 C06
+resource SERIAL_RX 1 A10
+resource SERIAL_RX 3 B11
+resource SERIAL_RX 6 C07
+resource INVERTER 1 C00
+resource I2C_SCL 1 B06
+resource I2C_SDA 1 B07
+resource LED 1 B05
+resource LED 2 B04
+resource SPI_SCK 1 A05
+resource SPI_SCK 2 B13
+resource SPI_SCK 3 C10
+resource SPI_MISO 1 A06
+resource SPI_MISO 2 B14
+resource SPI_MISO 3 C11
+resource SPI_MOSI 1 A07
+resource SPI_MOSI 2 B15
+resource SPI_MOSI 3 C12
+resource ESCSERIAL 1 C09
+resource CAMERA_CONTROL 1 B09
+resource ADC_BATT 1 C01
+resource ADC_RSSI 1 C02
+resource ADC_CURR 1 C03
+resource FLASH_CS 1 B03
+resource OSD_CS 1 B12
+resource GYRO_EXTI 1 C04
+resource GYRO_CS 1 A04
+resource USB_DETECT 1 C05
+
+# timer
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
+timer A03 AF1
+# pin A03: TIM2 CH4 (AF1)
+timer B00 AF2
+# pin B00: TIM3 CH3 (AF2)
+timer B01 AF1
+# pin B01: TIM1 CH3N (AF1)
+timer A02 AF1
+# pin A02: TIM2 CH3 (AF1)
+timer A00 AF2
+# pin A00: TIM5 CH1 (AF2)
+timer B09 AF3
+# pin B09: TIM11 CH1 (AF3)
+
+# dma
+dma ADC 1 1
+# ADC 1: DMA2 Stream 4 Channel 0
+dma pin A03 1
+# pin A03: DMA1 Stream 6 Channel 3
+dma pin B00 0
+# pin B00: DMA1 Stream 7 Channel 5
+dma pin B01 0
+# pin B01: DMA2 Stream 6 Channel 0
+dma pin A02 0
+# pin A02: DMA1 Stream 1 Channel 3
+dma pin A00 0
+# pin A00: DMA1 Stream 2 Channel 6
+
+# feature
+feature -RX_PARALLEL_PWM
+feature RX_MSP
+feature LED_STRIP
+feature OSD
+
+# serial
+serial 2 8192 115200 57600 0 115200
+
+# beeper
+beeper -RX_LOST
+
+# map
+map AERT1234
+
+# led
+led 0 5,4::C:1
+led 1 6,4::C:1
+led 2 7,4::C:1
+led 3 5,5::C:1
+led 4 6,5::C:1
+led 5 7,5::C:1
+led 6 5,6::C:1
+led 7 6,6::C:1
+led 8 7,6::C:1
+
+# aux
+aux 0 1 1 1500 2100 0 0
+aux 1 0 0 1500 2100 0 0
+
+# rxfail
+rxfail 3 h
+
+# master
+set acc_calibration = -6,3,26,1
+set mag_bustype = I2C
+set mag_i2c_device = 1
+set mag_hardware = NONE
+set baro_bustype = I2C
+set baro_i2c_device = 1
+set baro_hardware = NONE
+set rssi_src_frame_errors = ON
+set serialrx_provider = SBUS
+set blackbox_device = SPIFLASH
+set min_throttle = 1100
+set dshot_idle_value = 300
+set motor_pwm_protocol = DSHOT600
+set motor_output_reordering = 2,3,0,1,4,5,6,7
+set current_meter = ADC
+set battery_meter = ADC
+set ibata_scale = 80
+set beeper_inversion = ON
+set beeper_od = OFF
+set small_angle = 5
+set yaw_deadband = 10
+set pid_process_denom = 8
+set osd_vbat_pos = 2468
+set osd_current_pos = 2475
+set osd_altitude_pos = 2180
+set osd_avg_cell_voltage_pos = 2436
+set system_hse_mhz = 8
+set max7456_spi_bus = 2
+set dashboard_i2c_bus = 1
+set flash_spi_bus = 3
+set gyro_1_bustype = SPI
+set gyro_1_spibus = 1
+set gyro_1_sensor_align = CW180
+set gyro_1_align_yaw = 1800
+set gyro_2_spibus = 1
+
+profile 0
+
+# profile 0
+set p_pitch = 80
+set i_pitch = 60
+set d_pitch = 75
+set p_roll = 80
+set i_roll = 60
+set d_roll = 75
+
+rateprofile 0
+
+# rateprofile 0
+set roll_srate = 0
+set pitch_srate = 0
+
+# end the command batch
+batch end
+
+# 

--- a/MAMBAF405MK2V2.conf
+++ b/MAMBAF405MK2V2.conf
@@ -173,3 +173,5 @@ batch end
 
 # Save and Reboot
 save
+
+

--- a/MAMBAF405MK2V2.conf
+++ b/MAMBAF405MK2V2.conf
@@ -170,4 +170,6 @@ set pitch_srate = 0
 # end the command batch
 batch end
 
-# 
+
+# Save and Reboot
+save


### PR DESCRIPTION
This pull request adds a new Betaflight configuration file for the MAMBA F405 MK2 V2 flight controller. The file contains a complete hardware resource mapping, feature setup, and tuning parameters for the board.

Key additions in the configuration file:

**Hardware and Resource Mapping:**
* Specifies all pin assignments for motors, LEDs, serial ports, SPI/I2C buses, ADCs, and other hardware resources (`MAMBAF405MK2V2.conf`).

**Feature and Peripheral Setup:**
* Enables/disables features such as RX_MSP, LED_STRIP, and OSD; configures serial ports and beeper settings.

**Flight and Sensor Configuration:**
* Sets up flight parameters including PID tuning, motor protocol, gyro alignment, and sensor bus types.

**LED and AUX Channel Configuration:**
* Defines LED layout and AUX channel ranges for flight modes or switches.

**Miscellaneous Settings:**
* Includes battery, current, and blackbox settings, as well as system clock and SPI bus assignments.